### PR TITLE
[CHE-3904] Pattern Recognition Backend Tweaks

### DIFF
--- a/Duckling/Quantity/EN/Corpus.hs
+++ b/Duckling/Quantity/EN/Corpus.hs
@@ -74,13 +74,15 @@ allExamples = concat
              , "0.75 cup"
              , ".75 cups"
              ]
-  , examples (simple Piece 3 (Just "bags"))
-             [ "3 Pieces of bags"
-             , "3 piece of BaGs"
+  , examples (simple Piece 3 (Just "rods"))
+             [ "3 Pieces of rods"
+             , "3 pcs of rods"
              ]
   , examples (simple Piece 1 Nothing)
              [ "1 piece"
              , "a Piece"
+             , "a pcs"
+             , "1 pcs"
              ]
   , examples (simple Gram 500 (Just "strawberries"))
              [ "500 grams of strawberries"
@@ -128,6 +130,10 @@ allExamples = concat
               , "at least 4.0 oz of chocolate"
               , "over four ounces of chocolate"
               , "more than four ounces of chocolate"
+              ]
+  , examples (simple Tonne 1 Nothing)
+              [ "1 tonne"
+              , "a ton"
               ]
   , examples (simple Tonne 2 Nothing)
               [ "2 tonnes"

--- a/Duckling/Quantity/EN/Corpus.hs
+++ b/Duckling/Quantity/EN/Corpus.hs
@@ -134,13 +134,16 @@ allExamples = concat
   , examples (simple Tonne 1 Nothing)
               [ "1 tonne"
               , "a ton"
+              , "one t"
               ]
   , examples (simple Tonne 2 Nothing)
               [ "2 tonnes"
               , "2 tons"
+              , "2 t"
               ]
   , examples (simple Tonne 3 (Just "sugar"))
               [ "3 tonnes of sugar"
               , "3 tons of Sugar"
+              , "3 t of Sugar"
               ]
   ]

--- a/Duckling/Quantity/EN/Corpus.hs
+++ b/Duckling/Quantity/EN/Corpus.hs
@@ -46,13 +46,15 @@ allExamples = concat
              ]
   , examples (simple Gram 2 Nothing)
              [ "2 grams"
-             , "0.002 kg"
-             , "2/1000 kilograms"
-             , "2000 milligrams"
+             , "2g"
              ]
-  , examples (simple Gram 1000 Nothing)
+  , examples (simple Kilogram 1 Nothing)
              [ "a kilogram"
              , "a kg"
+             ]
+  , examples (simple Milligram 1 Nothing)
+             [ "a milligram"
+             , "a mg"
              ]
   , examples (simple Pound 1 Nothing)
              [ "a Pound"
@@ -72,12 +74,25 @@ allExamples = concat
              , "0.75 cup"
              , ".75 cups"
              ]
+  , examples (simple Piece 3 (Just "bags"))
+             [ "3 Pieces of bags"
+             , "3 piece of BaGs"
+             ]
+  , examples (simple Piece 1 Nothing)
+             [ "1 piece"
+             , "a Piece"
+             ]
   , examples (simple Gram 500 (Just "strawberries"))
              [ "500 grams of strawberries"
              , "500g of strawberries"
-             , "0.5 kilograms of strawberries"
+             ]
+  , examples (simple Milligram 500 (Just "strawberries"))
+             [ "500mg of strawberries"
+             , "500 milligram of strawberries"
+             ]
+  , examples (simple Kilogram 0.5 (Just "strawberries"))
+             [ "0.5 kilograms of strawberries"
              , "0.5 kg of strawberries"
-             , "500000mg of strawberries"
              ]
   , examples (between Gram (100,1000) (Just "strawberries"))
               [ "100-1000 gram of strawberries"
@@ -90,8 +105,11 @@ allExamples = concat
               , "~2-7 grams"
               , "from 2 to 7 g"
               , "between 2.0 g and about 7.0 g"
-              , "between 0.002 kg and about 0.007 kg"
               , "2 - ~7 grams"
+              ]
+  , examples (between Kilogram (2,7) Nothing)
+              [ "between 2 kg and about 7 kg"
+              , "around 2 -7 Kilograms"
               ]
   , examples (under Pound 6 (Just "meat"))
               [ "less than six pounds of meat"
@@ -110,5 +128,13 @@ allExamples = concat
               , "at least 4.0 oz of chocolate"
               , "over four ounces of chocolate"
               , "more than four ounces of chocolate"
+              ]
+  , examples (simple Tonne 2 Nothing)
+              [ "2 tonnes"
+              , "2 tons"
+              ]
+  , examples (simple Tonne 3 (Just "sugar"))
+              [ "3 tonnes of sugar"
+              , "3 tons of Sugar"
               ]
   ]

--- a/Duckling/Quantity/EN/Rules.hs
+++ b/Duckling/Quantity/EN/Rules.hs
@@ -33,7 +33,7 @@ import qualified Duckling.Quantity.Types as TQuantity
 quantities :: [(Text, String, TQuantity.Unit)]
 quantities =
   [ ("<quantity> cups", "(cups?)", TQuantity.Cup)
-  , ("<quantity> pieces", "(pieces?)", TQuantity.Piece)
+  , ("<quantity> pieces", "((pieces?)|pcs)", TQuantity.Piece)
   , ("<quantity> milligrams", "(m(illi)?g(ram)?s?)", TQuantity.Milligram)
   , ("<quantity> grams", "(g(ram)?s?)", TQuantity.Gram)
   , ("<quantity> kilograms", "(k(ilo)?g(ram)?s?)", TQuantity.Kilogram)

--- a/Duckling/Quantity/EN/Rules.hs
+++ b/Duckling/Quantity/EN/Rules.hs
@@ -33,22 +33,17 @@ import qualified Duckling.Quantity.Types as TQuantity
 quantities :: [(Text, String, TQuantity.Unit)]
 quantities =
   [ ("<quantity> cups", "(cups?)", TQuantity.Cup)
-  , ("<quantity> grams", "(((m(illi)?)|(k(ilo)?))?g(ram)?s?)", TQuantity.Gram)
+  , ("<quantity> pieces", "(pieces?)", TQuantity.Piece)
+  , ("<quantity> milligrams", "(m(illi)?g(ram)?s?)", TQuantity.Milligram)
+  , ("<quantity> grams", "(g(ram)?s?)", TQuantity.Gram)
+  , ("<quantity> kilograms", "(k(ilo)?g(ram)?s?)", TQuantity.Kilogram)
   , ("<quantity> lb", "((lb|pound)s?)", TQuantity.Pound)
   , ("<quantity> oz", "((ounces?)|oz)", TQuantity.Ounce)
+  , ("<quantity> tonnes", "(ton(ne)?s?)", TQuantity.Tonne)
   ]
 
 opsMap :: HashMap Text (Double -> Double)
-opsMap = HashMap.fromList
-  [ ( "milligram" , (/ 1000))
-  , ( "milligrams", (/ 1000))
-  , ( "mg"        , (/ 1000))
-  , ( "mgs"       , (/ 1000))
-  , ( "kilogram"  , (* 1000))
-  , ( "kilograms" , (* 1000))
-  , ( "kg"        , (* 1000))
-  , ( "kgs"       , (* 1000))
-  ]
+opsMap = HashMap.fromList []
 
 ruleNumeralQuantities :: [Rule]
 ruleNumeralQuantities = map go quantities

--- a/Duckling/Quantity/EN/Rules.hs
+++ b/Duckling/Quantity/EN/Rules.hs
@@ -39,7 +39,7 @@ quantities =
   , ("<quantity> kilograms", "(k(ilo)?g(ram)?s?)", TQuantity.Kilogram)
   , ("<quantity> lb", "((lb|pound)s?)", TQuantity.Pound)
   , ("<quantity> oz", "((ounces?)|oz)", TQuantity.Ounce)
-  , ("<quantity> tonnes", "(ton(ne)?s?)", TQuantity.Tonne)
+  , ("<quantity> tonnes", "(t(on(ne)?s?)?)", TQuantity.Tonne)
   ]
 
 opsMap :: HashMap Text (Double -> Double)

--- a/Duckling/Quantity/Types.hs
+++ b/Duckling/Quantity/Types.hs
@@ -28,9 +28,13 @@ import Prelude
 data Unit
   = Bowl
   | Cup
+  | Piece
   | Custom Text
   | Dish
+  | Milligram
   | Gram
+  | Kilogram
+  | Tonne
   | Ounce
   | Pint
   | Pound


### PR DESCRIPTION
### Pattern Recognition Tweaks
- New `Piece` quantity unit has been introduced
- New `Tonne` ([metric](https://en.wikipedia.org/wiki/Tonne)) quantity unit has been introduced
- New `Kilogram` quantity unit has been introduced
- New `Milligram` quantity unit has been introduced
- The `Gram` quantity unit does not cover Kilograms and Milligrams anymore and a conversion won't happen

### Examples
Input: 
> I need between 2 to 2.5 tons of water

Output:
```json
[
   {
      "latent" : false,
      "value" : {
         "to" : {
            "product" : "water",
            "unit" : "tonne",
            "value" : 2.5
         },
         "from" : {
            "unit" : "tonne",
            "product" : "water",
            "value" : 2
         },
         "type" : "interval"
      },
      "end" : 37,
      "dim" : "quantity",
      "start" : 7,
      "body" : "between 2 to 2.5 tons of water"
   }
]
```
The `Tonne` quantity unit works with `ton(s)`, `tonne(s)` as well.

---
Input:
> Only two pieces of bags would suffice

Output:
```json
[
   {
      "end" : 23,
      "latent" : false,
      "value" : {
         "type" : "value",
         "product" : "bags",
         "unit" : "piece",
         "value" : 2
      },
      "start" : 5,
      "body" : "two pieces of bags",
      "dim" : "quantity"
   }
]
```
---
Input:
> I need a sample of around 400 milligrams of Isopropanol

Output:
```json
[
   {
      "latent" : false,
      "end" : 55,
      "dim" : "quantity",
      "start" : 19,
      "body" : "around 400 milligrams of Isopropanol",
      "value" : {
         "unit" : "milligram",
         "type" : "value",
         "product" : "isopropanol",
         "value" : 400
      }
   }
]
```
The `Milligram` quantity unit works with `mg(s)` as well.

---
Input:
> We require no more than 2/10 kg of Sulfur as sample.

Output:
```json
[
   {
      "body" : "no more than 2/10 kg of Sulfur",
      "dim" : "quantity",
      "latent" : false,
      "value" : {
         "type" : "interval",
         "to" : {
            "product" : "sulfur",
            "value" : 0.2,
            "unit" : "kilogram"
         }
      },
      "end" : 41,
      "start" : 11
   }
]
```
The `Kilogram` quantity unit works with `kg(s)` as well.

### Corresponding Jira Issue
https://chemondis.atlassian.net/browse/CHE-3904